### PR TITLE
Discrepancy in cni configuration

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -94,7 +94,7 @@ https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/virtual-machine
 
 ```shell
 POD_CIDR="$(echo $(curl --silent -H Metadata:true "http://169.254.169.254/metadata/instance/compute/tags?api-version=2017-08-01&format=text") | cut -d : -f2)"
-cat > 10-bridge.conf <<EOF
+cat <<EOF | sudo tee /etc/cni/net.d/10-bridge.conf
 {
     "cniVersion": "0.3.1",
     "name": "bridge",
@@ -116,7 +116,7 @@ EOF
 Create the `loopback` network configuration file:
 
 ```shell
-cat > 99-loopback.conf <<EOF
+cat <<EOF | sudo tee /etc/cni/net.d/99-loopback.conf
 {
     "cniVersion": "0.3.1",
     "type": "loopback"


### PR DESCRIPTION
In the original repo you the `10-bridge.conf` & `99-loopback.conf` is placed in a specific directory not at the current directory. This was leading to a 

``` 
NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
```
When running `kubectl get nodes` 
I found the fix in the original repo at this commit (dated May 12): https://github.com/kelseyhightower/kubernetes-the-hard-way/commit/b974042d95c491aceed3374ac3f76f04bd3f98ed#diff-03d99155352c96169d8f7f7b99410320