### PR TITLE
Update 03-compute-resources.md

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -160,7 +160,8 @@ for i in 0 1 2; do
         --generate-ssh-keys \
         --nics controller-${i}-nic \
         --availability-set controller-as \
-        --nsg '' > /dev/null
+        --nsg '' \
+        --admin-username 'kuberoot' > /dev/null
 done
 ```
 


### PR DESCRIPTION
VM creation needs admin username specified. Does not accept default 'root'