### PR TITLE
Update 03-compute-resources.md

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -197,7 +197,8 @@ for i in 0 1 2; do
         --nics worker-${i}-nic \
         --tags pod-cidr=10.200.${i}.0/24 \
         --availability-set worker-as \
-        --nsg '' > /dev/null
+        --nsg '' \
+        --admin-username 'kuberoot' > /dev/null
 done
 ```
 


### PR DESCRIPTION
Add --admin-username switch to Worker nodes created. Default 'root' user is not accepted while creating VM's