### PR TITLE
Update 13-smoke-test.md

### DIFF
--- a/docs/13-smoke-test.md
+++ b/docs/13-smoke-test.md
@@ -162,7 +162,7 @@ In this section you will verify the ability to expose applications using a [Serv
 Expose the `nginx` deployment using a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) service:
 
 ```shell
-kubectl expose deployment nginx --port 80 --type NodePort
+kubectl expose pod nginx --port 80 --type NodePort
 ```
 
 > The LoadBalancer service type can not be used because your cluster is not configured with [cloud provider integration](https://kubernetes.io/docs/getting-started-guides/scratch/#cloud-provider). Setting up cloud provider integration is out of scope for this tutorial.


### PR DESCRIPTION
Nginx was created as a Pod earlier and not Deployment. So we need to use 'kubectl expose pod' and not 'kubectl expose deployment'