### PR TITLE
Removed --nsg flag from VM creation

### DIFF
--- a/docs/03-compute-resources.md
+++ b/docs/03-compute-resources.md
@@ -160,7 +160,6 @@ for i in 0 1 2; do
         --generate-ssh-keys \
         --nics controller-${i}-nic \
         --availability-set controller-as \
-        --nsg '' \
         --admin-username 'kuberoot' > /dev/null
 done
 ```
@@ -198,7 +197,6 @@ for i in 0 1 2; do
         --nics worker-${i}-nic \
         --tags pod-cidr=10.200.${i}.0/24 \
         --availability-set worker-as \
-        --nsg '' \
         --admin-username 'kuberoot' > /dev/null
 done
 ```


### PR DESCRIPTION
Hi there, 

I have removed the --nsg Flag from Creating Kubernetes Crontrollers and Workers in Chapter 3 because it was causing errors. 

If you specify the --nsg flag but won't provide any arguments it will return an error like:
```ERROR: az vm create: error: argument --nsg: expected one argument```

So I would suggest to remove the options because in that case it will work well. 
