### PR TITLE
Update 12-dns-addon.md

### DIFF
--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -32,7 +32,6 @@ kubectl get pods -l k8s-app=kube-dns -n kube-system
 ```
 NAME                       READY   STATUS    RESTARTS   AGE
 coredns-59845f77f8-b4x76   1/1     Running   0          15s
-coredns-59845f77f8-hlbtc   1/1     Running   0          15s
 ```
 
 ## Verification


### PR DESCRIPTION
After recent change to deployments/coredns.yaml, the replica count has been changed and now will default to 1, so the output of 
```
kubectl get pods -l k8s-app=kube-dns -n kube-system
```

will be 1 coredns pod