### PR TITLE
Update etcd download to 3.3.20

### DIFF
--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -22,15 +22,15 @@ Download the official etcd release binaries from the [etcd-io/etcd](https://gith
 
 ```shell
 wget -q --show-progress --https-only --timestamping \
-  "https://github.com/etcd-io/etcd/releases/download/v3.3.18/etcd-v3.3.18-linux-amd64.tar.gz"
+  "https://github.com/etcd-io/etcd/releases/download/v3.3.20/etcd-v3.3.20-linux-amd64.tar.gz"
 ```
 
 Extract and install the `etcd` server and the `etcdctl` command line utility:
 
 ```shell
 {
-  tar -xvf etcd-v3.3.18-linux-amd64.tar.gz
-  sudo mv etcd-v3.3.18-linux-amd64/etcd* /usr/local/bin/
+  tar -xvf etcd-v3.3.20-linux-amd64.tar.gz
+  sudo mv etcd-v3.3.20-linux-amd64/etcd* /usr/local/bin/
 }
 ```
 


### PR DESCRIPTION
3.3.18 assets do not appear to be available on the github page anymore.