### PR TITLE
Update 04-certificate-authority.md

### DIFF
--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -139,7 +139,7 @@ cat > ${instance}-csr.json <<EOF
 EOF
 
 EXTERNAL_IP=$(az network public-ip show -g kubernetes \
-  -n kubernetes-pip --query ipAddress -o tsv)
+  -n ${instance} --query ipAddress -o tsv)
 
 INTERNAL_IP=$(az vm show -d -n ${instance} -g kubernetes --query privateIps -o tsv)
 


### PR DESCRIPTION
Pass worker's public ip to hostnames when generating kubelet's certificates