### PR TITLE
Update 09-bootstrapping-kubernetes-workers.md

### DIFF
--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -64,12 +64,14 @@ Install the worker binaries:
 
 ```shell
 {
+  mkdir containerd
   sudo mv runc.amd64 runc
   chmod +x kubectl kube-proxy kubelet runc runsc
   sudo mv kubectl kube-proxy kubelet runc runsc /usr/local/bin/
   sudo tar -xvf crictl-v1.17.0-linux-amd64.tar.gz -C /usr/local/bin/
   sudo tar -xvf cni-plugins-linux-amd64-v0.8.5.tgz -C /opt/cni/bin/
-  sudo tar -xvf containerd-1.3.2.linux-amd64.tar.gz -C /
+  sudo tar -xvf containerd-1.3.2.linux-amd64.tar.gz -C containerd
+  sudo mv containerd/bin/* /bin/
 }
 ```
 


### PR DESCRIPTION
The current version was extracting everything in root of filesystem (corrupting the VM). Took over the commands from Kelsey Hightower's repo and seem to work well.